### PR TITLE
Update Android Gradle Plugin to 8.9.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 accompanist = "0.37.0"
 androidDesugarJdkLibs = "2.1.4"
 # AGP and tools should be updated together
-androidGradlePlugin = "8.9.0"
+androidGradlePlugin = "8.9.3"
 androidTools = "31.9.0"
 androidxActivity = "1.9.3"
 androidxAppCompat = "1.7.0"


### PR DESCRIPTION
Updates the Android Gradle Plugin version to 8.9.3 in the `gradle/libs.versions.toml` file.